### PR TITLE
Added Configuration Builder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	
 	<groupId>de.drachir000.utils</groupId>
 	<artifactId>simple-config-lib</artifactId>
-	<version>1.0</version>
+	<version>1.1-SNAPSHOT</version>
 	
 	<name>SimpleConfigLib</name>
 	<description>A Simple Library for the handling of JSON Configurations.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	
 	<groupId>de.drachir000.utils</groupId>
 	<artifactId>simple-config-lib</artifactId>
-	<version>1.1-SNAPSHOT</version>
+	<version>1.1</version>
 	
 	<name>SimpleConfigLib</name>
 	<description>A Simple Library for the handling of JSON Configurations.</description>

--- a/src/main/java/de/drachir000/utils/config/Configuration.java
+++ b/src/main/java/de/drachir000/utils/config/Configuration.java
@@ -18,7 +18,7 @@ public class Configuration {
 	 * Create a {@link Configuration} based on a {@link JSONObject}
 	 *
 	 * @param jsonObject The base {@link JSONObject}
-	 * @deprecated This is planned to be replaced by {@link SimpleConfigLib#configurationFromJSONObject(JSONObject)}!
+	 * @deprecated This is planned to be replaced by {@link SimpleConfigLib#buildConfiguration(JSONObject)}!
 	 * @see SimpleConfigLib
 	 */
 	@Deprecated

--- a/src/main/java/de/drachir000/utils/config/Configuration.java
+++ b/src/main/java/de/drachir000/utils/config/Configuration.java
@@ -18,7 +18,10 @@ public class Configuration {
 	 * Create a {@link Configuration} based on a {@link JSONObject}
 	 *
 	 * @param jsonObject The base {@link JSONObject}
+	 * @deprecated This is planned to be replaced by {@link SimpleConfigLib#configurationFromJSONObject(JSONObject)}!
+	 * @see SimpleConfigLib
 	 */
+	@Deprecated
 	public Configuration(JSONObject jsonObject) {
 		this.content = jsonObject;
 	}

--- a/src/main/java/de/drachir000/utils/config/SimpleConfigLib.java
+++ b/src/main/java/de/drachir000/utils/config/SimpleConfigLib.java
@@ -1,0 +1,18 @@
+package de.drachir000.utils.config;
+
+import org.json.JSONObject;
+
+public class SimpleConfigLib {
+	
+	/**
+	 * Constructs a {@link Configuration} object from a {@link JSONObject}.
+	 * Note that modifying the {@link JSONObject} <b>will</b> impact the {@link Configuration} and vice versa.
+	 *
+	 * @param jsonObject the {@link JSONObject} representing the {@link Configuration}
+	 * @return a {@link Configuration} object created from the {@link JSONObject}
+	 */
+	public static Configuration configurationFromJSONObject(JSONObject jsonObject) {
+		return new Configuration(jsonObject);
+	}
+	
+}

--- a/src/main/java/de/drachir000/utils/config/SimpleConfigLib.java
+++ b/src/main/java/de/drachir000/utils/config/SimpleConfigLib.java
@@ -12,6 +12,7 @@ public class SimpleConfigLib {
 	 * Creates an empty configuration.
 	 *
 	 * @return an empty {@link Configuration} object
+	 * @since 1.1
 	 */
 	public static Configuration emptyConfiguration() {
 		return new Configuration(new JSONObject());
@@ -23,8 +24,9 @@ public class SimpleConfigLib {
 	 *
 	 * @param jsonObject the {@link JSONObject} representing the {@link Configuration}
 	 * @return a {@link Configuration} object created from the {@link JSONObject}
+	 * @since 1.1
 	 */
-	public static Configuration configurationFromJSONObject(JSONObject jsonObject) {
+	public static Configuration buildConfiguration(JSONObject jsonObject) {
 		return new Configuration(jsonObject);
 	}
 	
@@ -34,8 +36,9 @@ public class SimpleConfigLib {
 	 * @param source the JSON string representing the configuration
 	 * @return a {@link Configuration} object created from the JSON string
 	 * @throws JSONException If there is a syntax error in the source string or a duplicated key.
+	 * @since 1.1
 	 */
-	public static Configuration configurationFromString(String source) throws JSONException {
+	public static Configuration buildConfiguration(String source) throws JSONException {
 		return new Configuration(new JSONObject(source));
 	}
 	

--- a/src/main/java/de/drachir000/utils/config/SimpleConfigLib.java
+++ b/src/main/java/de/drachir000/utils/config/SimpleConfigLib.java
@@ -1,8 +1,21 @@
 package de.drachir000.utils.config;
 
+import org.json.JSONException;
 import org.json.JSONObject;
 
+/**
+ * SimpleConfigLib is a class that provides static utility methods for working with configurations.
+ */
 public class SimpleConfigLib {
+	
+	/**
+	 * Creates an empty configuration.
+	 *
+	 * @return an empty {@link Configuration} object
+	 */
+	public static Configuration emptyConfiguration() {
+		return new Configuration(new JSONObject());
+	}
 	
 	/**
 	 * Constructs a {@link Configuration} object from a {@link JSONObject}.
@@ -13,6 +26,17 @@ public class SimpleConfigLib {
 	 */
 	public static Configuration configurationFromJSONObject(JSONObject jsonObject) {
 		return new Configuration(jsonObject);
+	}
+	
+	/**
+	 * Constructs a {@link Configuration} object from a JSON string.
+	 *
+	 * @param source the JSON string representing the configuration
+	 * @return a {@link Configuration} object created from the JSON string
+	 * @throws JSONException If there is a syntax error in the source string or a duplicated key.
+	 */
+	public static Configuration configurationFromString(String source) throws JSONException {
+		return new Configuration(new JSONObject(source));
 	}
 	
 }

--- a/src/test/java/de/drachir000/utils/config/SimpleConfigLibTest.java
+++ b/src/test/java/de/drachir000/utils/config/SimpleConfigLibTest.java
@@ -1,0 +1,52 @@
+package de.drachir000.utils.config;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class SimpleConfigLibTest {
+	
+	@Test
+	public void testEmptyConfiguration() {
+		
+		Configuration config = SimpleConfigLib.emptyConfiguration();
+		
+		assertNotNull(config);
+		
+		assertThrows(JSONException.class, () -> config.get("invalid-key"));
+		
+	}
+	
+	@Test
+	public void testConfigurationFromJSONObject() {
+		
+		JSONObject jsonObject = new JSONObject();
+		jsonObject.put("key-prev", "value-prev");
+		
+		Configuration config = SimpleConfigLib.buildConfiguration(jsonObject);
+		assertNotNull(config);
+		assertEquals("value-prev", config.getString("key-prev"));
+		
+		config.setString("key-after", "value-after");
+		assertEquals("value-after", jsonObject.getString("key-after"));
+		
+		assertThrows(JSONException.class, () -> config.get("invalid-key"));
+		
+	}
+	
+	@Test
+	public void testConfigurationFromString() {
+		
+		String source = "{\"key\":\"value\"}";
+		
+		Configuration config = SimpleConfigLib.buildConfiguration(source);
+		assertNotNull(config);
+		assertEquals("value", config.getString("key"));
+		
+		assertThrows(JSONException.class, () -> config.get("invalid-key"));
+		
+	}
+	
+}


### PR DESCRIPTION
Created the SimpleConfigLib class with util Configuration builder.

This will make the Configuration#Configuration Constructor deprecated and it should be made protected in the next main release.

TestCases for these changes are located in de.drachir000.utils.config.SimpleConfigLibTest.java

### Usage
```java
SimpleConfigLib.emptyConfiguration() // reurns new empty Configuration object
SimpleConfigLib.buildConfiguration(jsonObject) // returns new Configuraion object based on that JSONObject (the two instances are linked)
SimpleConfigLib.buildConfiguration(jsonString) // returns new Configuration object from a jsonString
```

Changes:
 * Add SimpleConfigLib utility class
 * Made Configuration#Configuration deprecated
 * Add configuration building methods to SimpleConfigLib
 * Add tests for SimpleConfigLib class
 * Changed project version to 1.1