### PR TITLE
Store Objects Serialized & Encoded

### DIFF
--- a/src/main/java/de/drachir000/utils/config/Configuration.java
+++ b/src/main/java/de/drachir000/utils/config/Configuration.java
@@ -4,6 +4,8 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.io.*;
+import java.util.Base64;
 import java.util.Map;
 import java.util.Set;
 
@@ -469,6 +471,57 @@ public class Configuration {
 	
 	protected JSONObject toJsonObject() {
 		return content;
+	}
+	
+	/**
+	 * Deserializes a serialized object.
+	 *
+	 * @param s the serialized object as a Base64 encoded string
+	 * @return the deserialized object
+	 * @throws IOException              if an I/O error occurs while deserializing
+	 * @throws ClassNotFoundException   if the class of the object to be deserialized is not found
+	 * @throws IllegalArgumentException if the string is null or empty
+	 * @throws SecurityException        if a security manager exists and its checkPermission method denies permission to deserialize
+	 * @throws NullPointerException     if the string is null or empty
+	 */
+	protected static Object deserialize(String s) throws IOException, ClassNotFoundException, IllegalArgumentException, SecurityException, NullPointerException {
+		
+		if (s == null || s.isBlank())
+			throw new NullPointerException("Cannot deserialize null or empty String!");
+		
+		byte[] data = Base64.getDecoder().decode(s);
+		
+		ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(data));
+		
+		Object o = ois.readObject();
+		ois.close();
+		
+		return o;
+		
+	}
+	
+	/**
+	 * Serializes an object into a Base64 encoded string.
+	 *
+	 * @param o The object to be serialized. Must implement the Serializable interface.
+	 * @return A Base64 encoded string representation of the serialized object.
+	 * @throws IOException          If an I/O error occurs while serializing the object.
+	 * @throws SecurityException    If a security violation occurs during serialization.
+	 * @throws NullPointerException If the object passed is null.
+	 */
+	protected static String serialize(Serializable o) throws IOException, SecurityException, NullPointerException {
+		
+		if (o == null)
+			throw new NullPointerException("null cannot be serialized!");
+		
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ObjectOutputStream oos = new ObjectOutputStream(baos);
+		
+		oos.writeObject(o);
+		oos.close();
+		
+		return Base64.getEncoder().encodeToString(baos.toByteArray());
+		
 	}
 	
 }

--- a/src/main/java/de/drachir000/utils/config/Configuration.java
+++ b/src/main/java/de/drachir000/utils/config/Configuration.java
@@ -30,6 +30,12 @@ public class Configuration {
 	
 	/**
 	 * Get the value {@link Object} associated with a key.
+	 * <b>Caution: Objects without explicit getters might get assigned by {@link Configuration#set(String, Object)}. However,
+	 * while serializing the {@link Configuration} ({@link Configuration#toString()}),
+	 * such {@link Configuration}s that are constructed from this string ({@link SimpleConfigLib#buildConfiguration(String)})
+	 * will contain a string representation of the Object associated with the key!
+	 * To prevent this, employ {@link Configuration#setEncoded(String, Serializable)} for setting
+	 * and {@link Configuration#getEncoded(String)} for retrieving these objects.</b>
 	 *
 	 * @param key A key string.
 	 * @return The {@link Object} associated with the key.
@@ -180,6 +186,12 @@ public class Configuration {
 	
 	/**
 	 * Get the value {@link Object} associated with a key, or the provided replacement value if the key is not set.
+	 * <b>Caution: Objects without explicit getters might get assigned by {@link Configuration#set(String, Object)}. However,
+	 * while serializing the {@link Configuration} ({@link Configuration#toString()}),
+	 * such {@link Configuration}s that are constructed from this string ({@link SimpleConfigLib#buildConfiguration(String)})
+	 * will contain a string representation of the Object associated with the key!
+	 * To prevent this, employ {@link Configuration#setEncoded(String, Serializable)} for setting
+	 * and {@link Configuration#getEncodedOrDefault(String, Object)} for retrieving these objects.</b>
 	 *
 	 * @param key          A key string.
 	 * @param defaultValue The fallback value
@@ -340,6 +352,12 @@ public class Configuration {
 	
 	/**
 	 * Save an {@link Object} value in the {@link Configuration}. If the value is null, then the key will be removed from the {@link Configuration} if it is present.
+	 * <b>Caution: Objects without explicit setters might get assigned by this method. However,
+	 * while serializing the {@link Configuration} ({@link Configuration#toString()}),
+	 * such {@link Configuration}s that are constructed from this string ({@link SimpleConfigLib#buildConfiguration(String)})
+	 * will contain a string representation of the Object associated with the key!
+	 * To prevent this, employ {@link Configuration#setEncoded(String, Serializable)} for setting
+	 * and {@link Configuration#getEncoded(String)} for retrieving these objects.</b>
 	 *
 	 * @param key   A key string.
 	 * @param value The {@link Object} Value to save.

--- a/src/main/java/de/drachir000/utils/config/Configuration.java
+++ b/src/main/java/de/drachir000/utils/config/Configuration.java
@@ -41,7 +41,7 @@ public class Configuration {
 	}
 	
 	/**
-	 * Retrieves the Base64 encoded {@link Serializable} object value associated with the given key.
+	 * Retrieves the {@link Serializable} {@link Object} value associated Base64 encoded with the given key.
 	 *
 	 * @param key The key of the value to retrieve.
 	 * @return The decoded {@link Serializable} {@link Object} associated with the given key.
@@ -507,6 +507,18 @@ public class Configuration {
 	 */
 	public boolean hasKey(String key) {
 		return content.has(key);
+	}
+	
+	/**
+	 * Determines whether the specified key corresponds to a Base64 encoded {@link Serializable} {@link Object}.
+	 *
+	 * @param key the key to check
+	 * @return true if the key corresponds to an encoded object, false otherwise
+	 */
+	public boolean isEncodedObject(String key) {
+		if (!hasKey(key))
+			return false;
+		return getEncodedOrDefault(key, null) != null;
 	}
 	
 	/**

--- a/src/main/java/de/drachir000/utils/config/Configuration.java
+++ b/src/main/java/de/drachir000/utils/config/Configuration.java
@@ -41,6 +41,24 @@ public class Configuration {
 	}
 	
 	/**
+	 * Retrieves the Base64 encoded {@link Serializable} object value associated with the given key.
+	 *
+	 * @param key The key of the value to retrieve.
+	 * @return The decoded {@link Serializable} {@link Object} associated with the given key.
+	 * @throws JSONException            If a JSON error occurs during the retrieval.
+	 * @throws IOException              If an IO error occurs during the retrieval.
+	 * @throws ClassNotFoundException   If a class cannot be found during the deserialization.
+	 * @throws IllegalArgumentException If an invalid argument is provided.
+	 * @throws SecurityException        If a security violation occurs during the retrieval.
+	 * @throws NullPointerException     If the value associated with the given key is null or blank.
+	 * @see Configuration#getEncodedOrDefault(String, Object)
+	 */
+	public Object getEncoded(String key) throws JSONException, IOException, ClassNotFoundException, IllegalArgumentException, SecurityException, NullPointerException {
+		String encoded = getString(key);
+		return deserialize(encoded);
+	}
+	
+	/**
 	 * Get the {@link String} associated with a key.
 	 *
 	 * @param key A key string.
@@ -172,6 +190,24 @@ public class Configuration {
 		if (!hasKey(key))
 			return defaultValue;
 		return get(key);
+	}
+	
+	/**
+	 * Get the decoded {@link Serializable} {@link Object} associated with a key, or the provided replacement value if the key is not set.
+	 *
+	 * @param key          A key string.
+	 * @param defaultValue The fallback value
+	 * @return The {@link Serializable} {@link Object} associated encoded with the key or the fallback value
+	 * @see Configuration#getEncoded(String)
+	 */
+	public Object getEncodedOrDefault(String key, Object defaultValue) {
+		if (!hasKey(key))
+			return defaultValue;
+		try {
+			return getEncoded(key);
+		} catch (JSONException | IOException | ClassNotFoundException | IllegalArgumentException | SecurityException | NullPointerException ignored) {
+			return defaultValue;
+		}
 	}
 	
 	/**
@@ -316,6 +352,23 @@ public class Configuration {
 		if (content.has(key))
 			prevValue = get(key);
 		content.put(key, value);
+		return prevValue;
+	}
+	
+	/**
+	 * Saves an {@link Serializable} {@link Object} value in the {@link Configuration}.
+	 * The value will be serialized and then stored as a Base64 encoded String.
+	 *
+	 * @param key   the key to set
+	 * @param value the value to set
+	 * @return the previous value associated with the key, or {@code null} if there was no previous value
+	 * @throws IOException          if there was an IO error during serialization
+	 * @throws SecurityException    if a security violation occurs
+	 * @throws NullPointerException if the key or value is {@code null}
+	 */
+	public Object setEncoded(String key, Serializable value) throws IOException, SecurityException, NullPointerException {
+		Object prevValue = getEncodedOrDefault(key, null);
+		content.put(key, serialize(value));
 		return prevValue;
 	}
 	

--- a/src/test/java/de/drachir000/utils/config/ConfigurationTest.java
+++ b/src/test/java/de/drachir000/utils/config/ConfigurationTest.java
@@ -4,6 +4,8 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Test;
 
+import java.io.*;
+import java.util.Base64;
 import java.util.Set;
 
 import static org.junit.Assert.*;
@@ -771,6 +773,61 @@ public class ConfigurationTest {
 		
 	}
 	
+	@Test
+	public void testSavingSerializedObjects() throws IOException, ClassNotFoundException {
+		
+		Configuration configuration = SimpleConfigLib.emptyConfiguration();
+		TestObject object = new TestObject(123, "Hello World!", TestEnum.VALUE_THREE, 456.78f);
+		
+		configuration.set("serializedObject", toString(object));
+		
+		String configString = configuration.toString();
+		Configuration reCreatedConfiguration1 = SimpleConfigLib.buildConfiguration(configString);
+		
+		assertEquals(object, fromString(configuration.getString("serializedObject")));
+		assertEquals(object, fromString(reCreatedConfiguration1.getString("serializedObject")));
+		
+	}
+	
+	@Test
+	public void testSavingObjects() throws IOException, ClassNotFoundException {
+		
+		Configuration configuration = SimpleConfigLib.emptyConfiguration();
+		TestObject object = new TestObject(123, "Hello World!", TestEnum.VALUE_THREE, 456.78f);
+		
+		configuration.set("object", object);
+		
+		String configString = configuration.toString();
+		Configuration reCreatedConfiguration1 = SimpleConfigLib.buildConfiguration(configString);
+		
+		assertEquals(object, configuration.get("object"));
+		assertNotEquals(object, reCreatedConfiguration1.get("object")); // Expected behaviour -> That's the reason, why we need a way to store objects serialized and Base64 encoded
+		
+	}
+	
+	/**
+	 * Read the object from Base64 string. Just a sketch!
+	 */
+	private static Object fromString(String s) throws IOException, ClassNotFoundException {
+		byte[] data = Base64.getDecoder().decode(s);
+		ObjectInputStream ois = new ObjectInputStream(
+				new ByteArrayInputStream(data));
+		Object o = ois.readObject();
+		ois.close();
+		return o;
+	}
+	
+	/**
+	 * Write the object to a Base64 string. Just a sketch!
+	 */
+	private static String toString(Serializable o) throws IOException {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ObjectOutputStream oos = new ObjectOutputStream(baos);
+		oos.writeObject(o);
+		oos.close();
+		return Base64.getEncoder().encodeToString(baos.toByteArray());
+	}
+	
 	private enum TestEnum {
 		
 		VALUE_ONE,
@@ -778,5 +835,7 @@ public class ConfigurationTest {
 		VALUE_THREE;
 		
 	}
+	
+	private record TestObject(int i, String s, TestEnum e, float f) implements Serializable {}
 	
 }

--- a/src/test/java/de/drachir000/utils/config/ConfigurationTest.java
+++ b/src/test/java/de/drachir000/utils/config/ConfigurationTest.java
@@ -26,6 +26,25 @@ public class ConfigurationTest {
 	}
 	
 	@Test
+	public void testGetEncoded() throws IOException, ClassNotFoundException {
+		
+		JSONObject jsonObject = new JSONObject();
+		
+		// System.out.println(Configuration.serialize(new TestObject(123, "Hello World!", TestEnum.VALUE_THREE, 456.78f)));
+		String encodedObject = "rO0ABXNyADdkZS5kcmFjaGlyMDAwLnV0aWxzLmNvbmZpZy5Db25maWd1cmF0aW9uVGVzdCRUZXN0T2JqZWN0AAAAAAAAAAA" +
+				"CAARGAAFmSQABaUwAAWV0ADdMZGUvZHJhY2hpcjAwMC91dGlscy9jb25maWcvQ29uZmlndXJhdGlvblRlc3QkVGVzdEVudW07TAABc3QAEkxqY" +
+				"XZhL2xhbmcvU3RyaW5nO3hwQ+Rj1wAAAHt+cgA1ZGUuZHJhY2hpcjAwMC51dGlscy5jb25maWcuQ29uZmlndXJhdGlvblRlc3QkVGVzdEVudW0" +
+				"AAAAAAAAAABIAAHhyAA5qYXZhLmxhbmcuRW51bQAAAAAAAAAAEgAAeHB0AAtWQUxVRV9USFJFRXQADEhlbGxvIFdvcmxkIQ==";
+		
+		jsonObject.put("key", encodedObject);
+		
+		Configuration configuration = new Configuration(jsonObject);
+		
+		assertEquals(new TestObject(123, "Hello World!", TestEnum.VALUE_THREE, 456.78f), configuration.getEncoded("key"));
+		
+	}
+	
+	@Test
 	public void testGetString() {
 		
 		JSONObject jsonObject = new JSONObject();
@@ -179,6 +198,22 @@ public class ConfigurationTest {
 	}
 	
 	@Test
+	public void testGetEncodedDefault1() throws IOException, ClassNotFoundException {
+		
+		JSONObject jsonObject = new JSONObject();
+		Configuration configuration = new Configuration(jsonObject);
+		
+		assertEquals(
+				new TestObject(123, "Hello World!", TestEnum.VALUE_THREE, 456.78f),
+				configuration.getEncodedOrDefault(
+						"invalid-key",
+						new TestObject(123, "Hello World!", TestEnum.VALUE_THREE, 456.78f)
+				)
+		);
+		
+	}
+	
+	@Test
 	public void testGetStringDefault1() {
 		
 		JSONObject jsonObject = new JSONObject();
@@ -317,6 +352,31 @@ public class ConfigurationTest {
 		
 		assertEquals(TestEnum.VALUE_ONE, configuration.getOrDefault("invalid-key", TestEnum.VALUE_ONE));
 		assertEquals(TestEnum.VALUE_ONE, configuration.getOrDefault(TestEnum.class, "invalid-key", TestEnum.VALUE_ONE));
+		
+	}
+	
+	@Test
+	public void testGetEncodedDefault2() throws IOException, ClassNotFoundException {
+		
+		JSONObject jsonObject = new JSONObject();
+		
+		// System.out.println(Configuration.serialize(new TestObject(123, "Hello World!", TestEnum.VALUE_THREE, 456.78f)));
+		String encodedObject = "rO0ABXNyADdkZS5kcmFjaGlyMDAwLnV0aWxzLmNvbmZpZy5Db25maWd1cmF0aW9uVGVzdCRUZXN0T2JqZWN0AAAAAAAAAAA" +
+				"CAARGAAFmSQABaUwAAWV0ADdMZGUvZHJhY2hpcjAwMC91dGlscy9jb25maWcvQ29uZmlndXJhdGlvblRlc3QkVGVzdEVudW07TAABc3QAEkxqY" +
+				"XZhL2xhbmcvU3RyaW5nO3hwQ+Rj1wAAAHt+cgA1ZGUuZHJhY2hpcjAwMC51dGlscy5jb25maWcuQ29uZmlndXJhdGlvblRlc3QkVGVzdEVudW0" +
+				"AAAAAAAAAABIAAHhyAA5qYXZhLmxhbmcuRW51bQAAAAAAAAAAEgAAeHB0AAtWQUxVRV9USFJFRXQADEhlbGxvIFdvcmxkIQ==";
+		
+		jsonObject.put("key", encodedObject);
+		
+		Configuration configuration = new Configuration(jsonObject);
+		
+		assertEquals(
+				new TestObject(123, "Hello World!", TestEnum.VALUE_THREE, 456.78f),
+				configuration.getEncodedOrDefault(
+						"key",
+						new TestObject(678, "Bye World!", TestEnum.VALUE_ONE, 123.45f)
+				)
+		);
 		
 	}
 	
@@ -470,6 +530,27 @@ public class ConfigurationTest {
 		configuration.set("key", 123.45f);
 		
 		assertEquals(123.45f, configuration.get("key"));
+		
+	}
+	
+	@Test
+	public void testSetEncoded() throws IOException, ClassNotFoundException {
+		
+		Configuration configuration = new Configuration(new JSONObject());
+		TestObject value = new TestObject(123, "Hello World!", TestEnum.VALUE_THREE, 456.78f);
+		
+		configuration.setEncoded("key", value);
+		configuration.set("key2", value);
+		
+		assertEquals(value, configuration.getEncoded("key"));
+		assertEquals(value, configuration.get("key2"));
+		
+		Configuration configurationReloaded = new Configuration(
+				new JSONObject(configuration.toString())
+		);
+		
+		assertEquals(value, configurationReloaded.getEncoded("key"));
+		assertNotEquals(value, configurationReloaded.get("key2")); // This is why the whole "save serialized and encoded" system is required
 		
 	}
 	
@@ -630,6 +711,25 @@ public class ConfigurationTest {
 	}
 	
 	@Test
+	public void testIsEncodedObject() throws IOException {
+		
+		TestObject value = new TestObject(123, "Hello World!", TestEnum.VALUE_THREE, 456.78f);
+		JSONObject jsonObject = new JSONObject();
+		
+		jsonObject.put("key", value);
+		
+		Configuration configuration = new Configuration(jsonObject);
+		configuration.setEncoded("key-encoded", value);
+		
+		assertTrue(configuration.hasKey("key"));
+		assertFalse(configuration.isEncodedObject("key"));
+		
+		assertTrue(configuration.hasKey("key-encoded"));
+		assertTrue(configuration.isEncodedObject("key-encoded"));
+		
+	}
+	
+	@Test
 	public void testToString() {
 		
 		JSONObject jsonObject = new JSONObject();
@@ -643,9 +743,10 @@ public class ConfigurationTest {
 	}
 	
 	@Test
-	public void testDeserialization1() {
+	public void testDeserialization1() throws IOException, ClassNotFoundException {
 		
-		JSONObject jsonObject = generateConfigDeserialization1();
+		TestObject value = new TestObject(123, "Hello World!", TestEnum.VALUE_THREE, 456.78f);
+		JSONObject jsonObject = generateConfigDeserialization1(value);
 		
 		Configuration configuration = new Configuration(
 				new JSONObject(
@@ -653,6 +754,7 @@ public class ConfigurationTest {
 				)
 		);
 		
+		assertEquals(value, configuration.getEncoded("encoded"));
 		assertEquals("value", configuration.getString("string"));
 		assertEquals(123, configuration.getInt("int"));
 		assertEquals(456L, configuration.getLong("long"));
@@ -667,9 +769,11 @@ public class ConfigurationTest {
 		
 	}
 	
-	private static JSONObject generateConfigDeserialization1() {
+	private static JSONObject generateConfigDeserialization1(TestObject value) throws IOException {
 		
 		JSONObject jsonObject = new JSONObject();
+		
+		jsonObject.put("encoded", Configuration.serialize(value));
 		
 		jsonObject.put("string", "value");
 		
@@ -699,9 +803,10 @@ public class ConfigurationTest {
 	}
 	
 	@Test
-	public void testDeserialization2() {
+	public void testDeserialization2() throws IOException, ClassNotFoundException {
 		
-		Configuration configObject = getConfigurationDeserialization2();
+		TestObject value = new TestObject(123, "Hello World!", TestEnum.VALUE_THREE, 456.78f);
+		Configuration configObject = getConfigurationDeserialization2(value);
 		
 		Configuration configuration = new Configuration(
 				new JSONObject(
@@ -709,6 +814,7 @@ public class ConfigurationTest {
 				)
 		);
 		
+		assertEquals(value, configuration.getEncoded("encoded"));
 		assertEquals("value", configuration.getString("string"));
 		assertEquals(123, configuration.getInt("int"));
 		assertEquals(456L, configuration.getLong("long"));
@@ -723,9 +829,11 @@ public class ConfigurationTest {
 		
 	}
 	
-	private static Configuration getConfigurationDeserialization2() {
+	private static Configuration getConfigurationDeserialization2(TestObject value) throws IOException {
 		
 		Configuration configObject = new Configuration(new JSONObject());
+		
+		configObject.setEncoded("encoded", value);
 		
 		configObject.setString("string", "value");
 		
@@ -770,38 +878,6 @@ public class ConfigurationTest {
 		assertEquals("value", configuration2.getString("key"));
 		assertEquals("value-2", configuration2.getString("key-2"));
 		assertEquals("value-2", jsonObject.getString("key-2"));
-		
-	}
-	
-	@Test
-	public void testSavingSerializedObjects() throws IOException, ClassNotFoundException {
-		
-		Configuration configuration = SimpleConfigLib.emptyConfiguration();
-		TestObject object = new TestObject(123, "Hello World!", TestEnum.VALUE_THREE, 456.78f);
-		
-		configuration.set("serializedObject", Configuration.serialize(object));
-		
-		String configString = configuration.toString();
-		Configuration reCreatedConfiguration1 = SimpleConfigLib.buildConfiguration(configString);
-		
-		assertEquals(object, Configuration.deserialize(configuration.getString("serializedObject")));
-		assertEquals(object, Configuration.deserialize(reCreatedConfiguration1.getString("serializedObject")));
-		
-	}
-	
-	@Test
-	public void testSavingObjects() {
-		
-		Configuration configuration = SimpleConfigLib.emptyConfiguration();
-		TestObject object = new TestObject(123, "Hello World!", TestEnum.VALUE_THREE, 456.78f);
-		
-		configuration.set("object", object);
-		
-		String configString = configuration.toString();
-		Configuration reCreatedConfiguration1 = SimpleConfigLib.buildConfiguration(configString);
-		
-		assertEquals(object, configuration.get("object"));
-		assertNotEquals(object, reCreatedConfiguration1.get("object")); // Expected behaviour -> That's the reason, why we need a way to store objects serialized and Base64 encoded
 		
 	}
 	

--- a/src/test/java/de/drachir000/utils/config/ConfigurationTest.java
+++ b/src/test/java/de/drachir000/utils/config/ConfigurationTest.java
@@ -4,8 +4,8 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Test;
 
-import java.io.*;
-import java.util.Base64;
+import java.io.IOException;
+import java.io.Serializable;
 import java.util.Set;
 
 import static org.junit.Assert.*;
@@ -779,18 +779,18 @@ public class ConfigurationTest {
 		Configuration configuration = SimpleConfigLib.emptyConfiguration();
 		TestObject object = new TestObject(123, "Hello World!", TestEnum.VALUE_THREE, 456.78f);
 		
-		configuration.set("serializedObject", toString(object));
+		configuration.set("serializedObject", Configuration.serialize(object));
 		
 		String configString = configuration.toString();
 		Configuration reCreatedConfiguration1 = SimpleConfigLib.buildConfiguration(configString);
 		
-		assertEquals(object, fromString(configuration.getString("serializedObject")));
-		assertEquals(object, fromString(reCreatedConfiguration1.getString("serializedObject")));
+		assertEquals(object, Configuration.deserialize(configuration.getString("serializedObject")));
+		assertEquals(object, Configuration.deserialize(reCreatedConfiguration1.getString("serializedObject")));
 		
 	}
 	
 	@Test
-	public void testSavingObjects() throws IOException, ClassNotFoundException {
+	public void testSavingObjects() {
 		
 		Configuration configuration = SimpleConfigLib.emptyConfiguration();
 		TestObject object = new TestObject(123, "Hello World!", TestEnum.VALUE_THREE, 456.78f);
@@ -803,29 +803,6 @@ public class ConfigurationTest {
 		assertEquals(object, configuration.get("object"));
 		assertNotEquals(object, reCreatedConfiguration1.get("object")); // Expected behaviour -> That's the reason, why we need a way to store objects serialized and Base64 encoded
 		
-	}
-	
-	/**
-	 * Read the object from Base64 string. Just a sketch!
-	 */
-	private static Object fromString(String s) throws IOException, ClassNotFoundException {
-		byte[] data = Base64.getDecoder().decode(s);
-		ObjectInputStream ois = new ObjectInputStream(
-				new ByteArrayInputStream(data));
-		Object o = ois.readObject();
-		ois.close();
-		return o;
-	}
-	
-	/**
-	 * Write the object to a Base64 string. Just a sketch!
-	 */
-	private static String toString(Serializable o) throws IOException {
-		ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		ObjectOutputStream oos = new ObjectOutputStream(baos);
-		oos.writeObject(o);
-		oos.close();
-		return Base64.getEncoder().encodeToString(baos.toByteArray());
 	}
 	
 	private enum TestEnum {


### PR DESCRIPTION
When storing Objects that are not of the following types:
- String
- Primitives
- JSONObject
- JSONArray
- Enum (any kind)

the Object will be represented as a String Object in the return value of the method Configuration#toString().
To enable retrieval of all types of objects after reloading a Configuration from a String, this approach introduces a mechanism to encode Serializable Objects using Base64. This ensures a more straightforward and feasible persistent object storage.

### Usage
```java
config.setEncoded("key", object); // This stores any Object that implements the Serializable interface as a Base64 encoded String in the Configuration
config.getEncoded("key"); // This returns the previously stored Object, already decoded and deserialized
config.getEncodedOrDefault("key", defaultObject); // This returns the previously stored Object already decoded and deserialized or, alternatively, the provided default object
config.isEncodedObject("key"); // This returns true if the key corresponds to an encoded object, false otherwise (It's not true when the value is a Base64 String, but not a deserializable object)
```

### Changes
- Integrated the serialization and encoding logic into the Configuration class
- Implemented the previously added logic in getters and a setter
- Developed the `isEncodedObject(String key)` method in the Configuration class
- Updated and created tests
- Added warnings to the Configuration class's documentation