### PR TITLE
Utility for saving to and loading from File

### DIFF
--- a/src/main/java/de/drachir000/utils/config/SimpleConfigLib.java
+++ b/src/main/java/de/drachir000/utils/config/SimpleConfigLib.java
@@ -100,15 +100,22 @@ public class SimpleConfigLib {
 	 */
 	public static Configuration load(File file) throws IOException, JSONException {
 		
-		BufferedReader reader = new BufferedReader(new FileReader(file));
 		StringBuilder builder = new StringBuilder();
 		
-		String line;
-		while ((line = reader.readLine()) != null) {
-			builder.append(line);
+		try {
+			BufferedReader reader = new BufferedReader(new FileReader(file));
+			
+			String line;
+			while ((line = reader.readLine()) != null) {
+				builder.append(line);
+			}
+			
+			reader.close();
+		} catch (FileNotFoundException ignored) {
 		}
 		
-		reader.close();
+		if (builder.toString().isBlank())
+			return emptyConfiguration();
 		
 		return buildConfiguration(builder.toString());
 		

--- a/src/main/java/de/drachir000/utils/config/SimpleConfigLib.java
+++ b/src/main/java/de/drachir000/utils/config/SimpleConfigLib.java
@@ -63,6 +63,33 @@ public class SimpleConfigLib {
 	}
 	
 	/**
+	 * Saves a {@link Configuration} to a {@link File}.
+	 *
+	 * @param configuration        the {@link Configuration} to be saved
+	 * @param file                 the {@link File} to save the {@link Configuration} to
+	 * @param encodeUnknownObjects represents whether to encode unknown objects. If this is set to true, any {@link Serializable}
+	 *                             object, which is not recognized and hence would be converted into a String for the result, will be
+	 *                             serialized and Base64 encoded. Such objects can then be fetched using {@link Configuration#getEncoded(String)}.
+	 *                             This setting does not modify this Object, only the manner these objects are stored within the File by this method.
+	 * @throws IOException if an I/O error occurs while writing to the file
+	 * @since 1.3
+	 */
+	public static void save(Configuration configuration, File file, boolean encodeUnknownObjects) throws IOException {
+		
+		if (!encodeUnknownObjects) {
+			save(configuration, file);
+			return;
+		}
+		
+		BufferedWriter writer = new BufferedWriter(new FileWriter(file));
+		writer.write(configuration.toString(true));
+		
+		writer.flush();
+		writer.close();
+		
+	}
+	
+	/**
 	 * Reads a JSON string from a {@link File} and constructs a {@link Configuration} object from it.
 	 *
 	 * @param file the {@link File} to read the JSON string from

--- a/src/main/java/de/drachir000/utils/config/SimpleConfigLib.java
+++ b/src/main/java/de/drachir000/utils/config/SimpleConfigLib.java
@@ -3,6 +3,8 @@ package de.drachir000.utils.config;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.io.*;
+
 /**
  * SimpleConfigLib is a class that provides static utility methods for working with configurations.
  */
@@ -40,6 +42,49 @@ public class SimpleConfigLib {
 	 */
 	public static Configuration buildConfiguration(String source) throws JSONException {
 		return new Configuration(new JSONObject(source));
+	}
+	
+	/**
+	 * Saves a {@link Configuration} to a {@link File}.
+	 *
+	 * @param configuration the {@link Configuration} to be saved
+	 * @param file          the {@link File} to save the {@link Configuration} to
+	 * @throws IOException if an I/O error occurs while writing to the file
+	 * @since 1.3
+	 */
+	public static void save(Configuration configuration, File file) throws IOException {
+		
+		BufferedWriter writer = new BufferedWriter(new FileWriter(file));
+		writer.write(configuration.toString());
+		
+		writer.flush();
+		writer.close();
+		
+	}
+	
+	/**
+	 * Reads a JSON string from a {@link File} and constructs a {@link Configuration} object from it.
+	 *
+	 * @param file the {@link File} to read the JSON string from
+	 * @return a {@link Configuration} object constructed from the JSON string
+	 * @throws IOException   if an I/O error occurs while reading the file
+	 * @throws JSONException if there is a syntax error in the JSON string or a duplicated key
+	 * @since 1.3
+	 */
+	public static Configuration load(File file) throws IOException, JSONException {
+		
+		BufferedReader reader = new BufferedReader(new FileReader(file));
+		StringBuilder builder = new StringBuilder();
+		
+		String line;
+		while ((line = reader.readLine()) != null) {
+			builder.append(line);
+		}
+		
+		reader.close();
+		
+		return buildConfiguration(builder.toString());
+		
 	}
 	
 }

--- a/src/main/java/de/drachir000/utils/config/SimpleConfigLib.java
+++ b/src/main/java/de/drachir000/utils/config/SimpleConfigLib.java
@@ -53,13 +53,7 @@ public class SimpleConfigLib {
 	 * @since 1.3
 	 */
 	public static void save(Configuration configuration, File file) throws IOException {
-		
-		BufferedWriter writer = new BufferedWriter(new FileWriter(file));
-		writer.write(configuration.toString());
-		
-		writer.flush();
-		writer.close();
-		
+		save(configuration, file, false);
 	}
 	
 	/**
@@ -76,13 +70,8 @@ public class SimpleConfigLib {
 	 */
 	public static void save(Configuration configuration, File file, boolean encodeUnknownObjects) throws IOException {
 		
-		if (!encodeUnknownObjects) {
-			save(configuration, file);
-			return;
-		}
-		
 		BufferedWriter writer = new BufferedWriter(new FileWriter(file));
-		writer.write(configuration.toString(true));
+		writer.write(configuration.toString(encodeUnknownObjects));
 		
 		writer.flush();
 		writer.close();

--- a/src/test/java/de/drachir000/utils/config/ConfigurationTest.java
+++ b/src/test/java/de/drachir000/utils/config/ConfigurationTest.java
@@ -943,7 +943,7 @@ public class ConfigurationTest {
 		
 	}
 	
-	private enum TestEnum {
+	enum TestEnum {
 		
 		VALUE_ONE,
 		VALUE_TWO,
@@ -951,6 +951,7 @@ public class ConfigurationTest {
 		
 	}
 	
-	private record TestObject(int i, String s, TestEnum e, float f) implements Serializable {}
+	protected record TestObject(int i, String s, TestEnum e, float f) implements Serializable {
+	}
 	
 }

--- a/src/test/java/de/drachir000/utils/config/SimpleConfigLibTest.java
+++ b/src/test/java/de/drachir000/utils/config/SimpleConfigLibTest.java
@@ -53,13 +53,34 @@ public class SimpleConfigLibTest {
 	}
 	
 	@Test
-	public void testFiles() throws IOException {
+	public void testSaveFile() throws IOException {
 		
 		Configuration configuration = SimpleConfigLib.emptyConfiguration();
 		File file = new File("settings.json");
 		
 		if (file.exists())
 			assertTrue(file.delete());
+		
+		configuration.setString("key", "value");
+		
+		SimpleConfigLib.save(configuration, file);
+		
+		assertTrue(file.exists());
+		
+		Configuration loadedConfig = SimpleConfigLib.load(file);
+		assertEquals("value", loadedConfig.getString("key"));
+		
+	}
+	
+	@Test
+	public void testLoadFile() throws IOException {
+		
+		File file = new File("settings.json");
+		
+		if (file.exists())
+			assertTrue(file.delete());
+		
+		Configuration configuration = SimpleConfigLib.load(file);
 		
 		configuration.setString("key", "value");
 		

--- a/src/test/java/de/drachir000/utils/config/SimpleConfigLibTest.java
+++ b/src/test/java/de/drachir000/utils/config/SimpleConfigLibTest.java
@@ -53,7 +53,7 @@ public class SimpleConfigLibTest {
 	}
 	
 	@Test
-	public void testSaveFile() throws IOException {
+	public void testSaveFile1() throws IOException {
 		
 		Configuration configuration = SimpleConfigLib.emptyConfiguration();
 		File file = new File("settings.json");
@@ -69,6 +69,42 @@ public class SimpleConfigLibTest {
 		
 		Configuration loadedConfig = SimpleConfigLib.load(file);
 		assertEquals("value", loadedConfig.getString("key"));
+		
+	}
+	
+	@Test
+	public void testSaveFile2() throws IOException, ClassNotFoundException {
+		
+		Configuration configuration = SimpleConfigLib.emptyConfiguration();
+		File file = new File("settings.json");
+		ConfigurationTest.TestObject value = new ConfigurationTest.TestObject(123, "Hello World!", ConfigurationTest.TestEnum.VALUE_THREE, 456.78f);
+		
+		if (file.exists())
+			assertTrue(file.delete());
+		
+		configuration.set("key", value);
+		
+		assertEquals(value, configuration.get("key"));
+		assertFalse(configuration.isEncodedObject("key"));
+		
+		SimpleConfigLib.save(configuration, file, true);
+		
+		assertTrue(file.exists());
+		
+		Configuration loadedConfig1 = SimpleConfigLib.load(file);
+		assertTrue(loadedConfig1.isEncodedObject("key"));
+		assertEquals(value, loadedConfig1.getEncoded("key"));
+		
+		if (file.exists())
+			assertTrue(file.delete());
+		
+		SimpleConfigLib.save(configuration, file);
+		
+		assertTrue(file.exists());
+		
+		Configuration loadedConfig2 = SimpleConfigLib.load(file);
+		assertFalse(loadedConfig2.isEncodedObject("key"));
+		assertThrows(IllegalArgumentException.class, () -> loadedConfig2.getEncoded("key"));
 		
 	}
 	

--- a/src/test/java/de/drachir000/utils/config/SimpleConfigLibTest.java
+++ b/src/test/java/de/drachir000/utils/config/SimpleConfigLibTest.java
@@ -4,6 +4,9 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
 
+import java.io.File;
+import java.io.IOException;
+
 import static org.junit.Assert.*;
 
 public class SimpleConfigLibTest {
@@ -46,6 +49,26 @@ public class SimpleConfigLibTest {
 		assertEquals("value", config.getString("key"));
 		
 		assertThrows(JSONException.class, () -> config.get("invalid-key"));
+		
+	}
+	
+	@Test
+	public void testFiles() throws IOException {
+		
+		Configuration configuration = SimpleConfigLib.emptyConfiguration();
+		File file = new File("settings.json");
+		
+		if (file.exists())
+			assertTrue(file.delete());
+		
+		configuration.setString("key", "value");
+		
+		SimpleConfigLib.save(configuration, file);
+		
+		assertTrue(file.exists());
+		
+		Configuration loadedConfig = SimpleConfigLib.load(file);
+		assertEquals("value", loadedConfig.getString("key"));
 		
 	}
 	


### PR DESCRIPTION
This introduces two static methods in the `SimpleConfigLib` class. The role of these methods is to manage the saving and loading of Configuration objects to and from files.

<details><summary>Usage</summary>
<p>

```java
SimpleConfigLib.save(config, file) // Saves the Configuration Object 'config' into the File 'file'
SimpleConfigLib.load(file) // Returns a Configuration Object that represents the JSONString saved in the File 'file'
``` 

</p>
</details>
<details><summary>Changes</summary>
<p>

- Developed load and save methods
- Incorporated a test case

</p>
</details> 